### PR TITLE
add FFT feature, modify command

### DIFF
--- a/Client_Data_Saving.py
+++ b/Client_Data_Saving.py
@@ -83,7 +83,7 @@ def jsonSave(path, jsonFile):
         json.dump(jsonFile, f, indent=4)
 
 def got_callback(topic, msg):
-    # 무슨이유잊니 4 or 5 두개가 왔다갔다... ㅠ  보고 처리요망
+    # 무슨이유인지 4 or 5 두개가 왔다갔다... ㅠ  보고 처리요망
     aename=topic[5] 
     if aename in ae:
         print('  Callback: got command for me =====>')

--- a/Periodical_Degree.py
+++ b/Periodical_Degree.py
@@ -79,7 +79,7 @@ def read(aename):
         print(url, json.dumps(r.json()))
 
 def tick():
-    read('ae.025742-TI_A1_01_X')
+    read('ae.025742-TI_A1_01_X') # 추후 conf.ae에서 ae name을 가져오는 방식으로 수정이 필요함
     threading.Timer(measureperiod, tick).start()
     
 time.sleep(measureperiod)

--- a/Periodical_Displacement.py
+++ b/Periodical_Displacement.py
@@ -25,7 +25,9 @@ ae = conf.ae
 
 root=conf.root
 
-
+# string find_pathlist()
+# 통계의 대상이 될 파일 path를 return합니다.
+# 저장되어있는 json file의 생성일자를 모두 살펴본 후, 가장 최근에 생성된 파일을 골라냅니다.
 def find_path():
     global measureperiod
     path = "./raw_data/Displacement"
@@ -81,7 +83,7 @@ def read(aename):
         print(url, json.dumps(r.json()))
 
 def tick():
-    read('ae.025742-DI_A1_01_X')
+    read('ae.025742-DI_A1_01_X') # 추후 conf.ae에서 ae name을 가져오는 방식으로 수정이 필요함
     threading.Timer(measureperiod, tick).start()
     
 time.sleep(measureperiod)

--- a/Periodical_Temperature.py
+++ b/Periodical_Temperature.py
@@ -25,7 +25,9 @@ ae = conf.ae
 
 root=conf.root
 
-
+# string find_pathlist()
+# 통계의 대상이 될 파일 path를 return합니다.
+# 저장되어있는 json file의 생성일자를 모두 살펴본 후, 가장 최근에 생성된 파일을 골라냅니다.
 def find_path():
     global measureperiod
     path = "./raw_data/Temperature"
@@ -81,7 +83,7 @@ def read(aename):
         print(url, json.dumps(r.json()))
 
 def tick():
-    read('ae.025742-TP_A1_01_X')
+    read('ae.025742-TP_A1_01_X') # 추후 conf.ae에서 ae name을 가져오는 방식으로 수정이 필요함
     threading.Timer(measureperiod, tick).start()
     
 time.sleep(measureperiod)

--- a/Raw_Acceleration.py
+++ b/Raw_Acceleration.py
@@ -1,0 +1,87 @@
+# Raw_Acceleration.py
+# date : 2022-05-06
+# 작성자 : ino-on, 주수아
+# 정해진 주기마다 http file server에 raw data를 전송합니다.
+
+from calendar import c
+from encodings import utf_8
+import threading
+import requests
+import json
+import os
+import sys
+import time
+from datetime import datetime
+import numpy as np
+
+measureperiod = 10 # 단위는 sec. 추후 conf.py의 rawperiod로 수정요망
+import conf
+
+connect = conf.config_connect
+
+host = connect["uploadip"]
+port = 2883 # 통일성을 위해 추후 port = connect["uploadport"]로 바꿔야할듯합니다만, uploadport의 기본값이 건기연 서버의 포트와 달라(80) 임시로 상수를 입력해두었습니다.
+
+root=conf.root
+
+last_timestamp = 0
+
+# list find_pathlist()
+# 전송의 대상이 될 파일 list를 출력합니다.
+# 저장되어있는 json file의 생성일자를 모두 살펴본 후, measureperiod동안 생성된 데이터의 path list를 골라냅니다.
+def find_pathlist():
+    global last_timestamp
+    global measureperiod
+    path = "./raw_data/Acceleration"
+    file_list = os.listdir(path)
+    present_time = time.time()
+    data_path_list = list()
+
+    if last_timestamp == 0 : # 최초 실행시, 데이터 생성일자에 따라 전송할 데이터를 골라낸다
+        for i in range (len(file_list)):
+            file_time = os.path.getmtime(path+'/'+file_list[i])
+            time_gap = present_time-file_time
+            if time_gap <= measureperiod: # 추후 데이터 수집 범위 10분으로 고정 예정
+                data_path_list.append(path+'/'+file_list[i])
+                if last_timestamp < file_time:
+                    last_timestamp = file_time # 가장 최근 파일의 timestamp를 기록한다. delay에 의한 누락을 방지하기 위한 작업.
+                #print(file_list[i])
+        return data_path_list
+
+    else: # 최초 실행이 아닌 경우, 기존에 저장해둔 가장 마지막에 전송한 data의 생성일자를 이용해 전송할 데이터를 골라낸다
+        next_timestamp = last_timestamp # 새로운 last_timestamp 갱신을 위해 새로운 변수 생성
+        for i in range(len(file_list)):
+            file_time = os.path.getmtime(path+'/'+file_list[i])
+            # 이전에 보냈던 latest 파일보다 더욱 최근 파일인 경우, 전송을 시행
+            if file_time > last_timestamp:
+                data_path_list.append(path+'/'+file_list[i])
+                #print(file_list[i])
+                if next_timestamp < file_time:
+                    next_timestamp = file_time # 가장 최근 파일의 timestamp를 기록한다. delay에 의한 누락을 방지하기 위한 작업.
+        last_timestamp = next_timestamp # 작업이 끝나면 last_timestamp를 새로운 값으로 갱신
+        return data_path_list
+
+
+def transport():
+    global host
+    global port
+    global last_timestamp
+    path_list = find_pathlist()
+
+    # 전송의 대상이 되는 파일이 전혀 없었을 경우, 전송을 수행하지 않습니다.
+    if len(path_list) == 0:
+        print("no data to upload")
+        print("waiting...")
+
+    url = F"http://{host}:{port}/upload"
+
+    for i in range(len(path_list)): # 지정된 data path에 존재하는 모든 file에 대해 전송 시행
+        r = requests.post("http://218.232.234.232:2883/upload", data = {"keyValue1":12345}, files = {"attachment":open(path_list[i], "rb")})
+        print(r.text)
+            
+def tick():
+    transport()
+    threading.Timer(measureperiod, tick).start()
+    
+time.sleep(measureperiod)
+tick()

--- a/Raw_Degree.py
+++ b/Raw_Degree.py
@@ -1,0 +1,87 @@
+# Raw_Degree.py
+# date : 2022-05-06
+# 작성자 : ino-on, 주수아
+# 정해진 주기마다 http file server에 raw data를 전송합니다.
+
+from calendar import c
+from encodings import utf_8
+import threading
+import requests
+import json
+import os
+import sys
+import time
+from datetime import datetime
+import numpy as np
+
+measureperiod = 10 # 단위는 sec. 추후 conf.py의 rawperiod로 수정요망
+import conf
+
+connect = conf.config_connect
+
+host = connect["uploadip"]
+port = 2883 # 통일성을 위해 추후 port = connect["uploadport"]로 바꿔야할듯합니다만, uploadport의 기본값이 건기연 서버의 포트와 달라(80) 임시로 상수를 입력해두었습니다.
+
+root=conf.root
+
+last_timestamp = 0
+
+# list find_pathlist()
+# 전송의 대상이 될 파일 list를 출력합니다.
+# 저장되어있는 json file의 생성일자를 모두 살펴본 후, measureperiod동안 생성된 데이터의 path list를 골라냅니다.
+def find_pathlist():
+    global last_timestamp
+    global measureperiod
+    path = "./raw_data/Degree"
+    file_list = os.listdir(path)
+    present_time = time.time()
+    data_path_list = list()
+
+    if last_timestamp == 0 : # 최초 실행시, 데이터 생성일자에 따라 전송할 데이터를 골라낸다
+        for i in range (len(file_list)):
+            file_time = os.path.getmtime(path+'/'+file_list[i])
+            time_gap = present_time-file_time
+            if time_gap <= measureperiod: # 추후 데이터 수집 범위 10분으로 고정 예정
+                data_path_list.append(path+'/'+file_list[i])
+                if last_timestamp < file_time:
+                    last_timestamp = file_time # 가장 최근 파일의 timestamp를 기록한다. delay에 의한 누락을 방지하기 위한 작업.
+                #print(file_list[i])
+        return data_path_list
+
+    else: # 최초 실행이 아닌 경우, 기존에 저장해둔 가장 마지막에 전송한 data의 생성일자를 이용해 전송할 데이터를 골라낸다
+        next_timestamp = last_timestamp # 새로운 last_timestamp 갱신을 위해 새로운 변수 생성
+        for i in range(len(file_list)):
+            file_time = os.path.getmtime(path+'/'+file_list[i])
+            # 이전에 보냈던 latest 파일보다 더욱 최근 파일인 경우, 전송을 시행
+            if file_time > last_timestamp:
+                data_path_list.append(path+'/'+file_list[i])
+                #print(file_list[i])
+                if next_timestamp < file_time:
+                    next_timestamp = file_time # 가장 최근 파일의 timestamp를 기록한다. delay에 의한 누락을 방지하기 위한 작업.
+        last_timestamp = next_timestamp # 작업이 끝나면 last_timestamp를 새로운 값으로 갱신
+        return data_path_list
+
+
+def transport():
+    global host
+    global port
+    global last_timestamp
+    path_list = find_pathlist()
+
+    # 전송의 대상이 되는 파일이 전혀 없었을 경우, 전송을 수행하지 않습니다.
+    if len(path_list) == 0:
+        print("no data to upload")
+        print("waiting...")
+
+    url = F"http://{host}:{port}/upload"
+
+    for i in range(len(path_list)): # 지정된 data path에 존재하는 모든 file에 대해 전송 시행
+        r = requests.post("http://218.232.234.232:2883/upload", data = {"keyValue1":12345}, files = {"attachment":open(path_list[i], "rb")})
+        print(r.text)
+            
+def tick():
+    transport()
+    threading.Timer(measureperiod, tick).start()
+    
+time.sleep(measureperiod)
+tick()

--- a/Raw_Displacement.py
+++ b/Raw_Displacement.py
@@ -1,0 +1,87 @@
+# Raw_Displacement.py
+# date : 2022-05-06
+# 작성자 : ino-on, 주수아
+# 정해진 주기마다 http file server에 raw data를 전송합니다.
+
+from calendar import c
+from encodings import utf_8
+import threading
+import requests
+import json
+import os
+import sys
+import time
+from datetime import datetime
+import numpy as np
+
+measureperiod = 10 # 단위는 sec. 추후 conf.py의 rawperiod로 수정요망
+import conf
+
+connect = conf.config_connect
+
+host = connect["uploadip"]
+port = 2883 # 통일성을 위해 추후 port = connect["uploadport"]로 바꿔야할듯합니다만, uploadport의 기본값이 건기연 서버의 포트와 달라(80) 임시로 상수를 입력해두었습니다.
+
+root=conf.root
+
+last_timestamp = 0
+
+# list find_pathlist()
+# 전송의 대상이 될 파일 list를 출력합니다.
+# 저장되어있는 json file의 생성일자를 모두 살펴본 후, measureperiod동안 생성된 데이터의 path list를 골라냅니다.
+def find_pathlist():
+    global last_timestamp
+    global measureperiod
+    path = "./raw_data/Displacement"
+    file_list = os.listdir(path)
+    present_time = time.time()
+    data_path_list = list()
+
+    if last_timestamp == 0 : # 최초 실행시, 데이터 생성일자에 따라 전송할 데이터를 골라낸다
+        for i in range (len(file_list)):
+            file_time = os.path.getmtime(path+'/'+file_list[i])
+            time_gap = present_time-file_time
+            if time_gap <= measureperiod: # 추후 데이터 수집 범위 10분으로 고정 예정
+                data_path_list.append(path+'/'+file_list[i])
+                if last_timestamp < file_time:
+                    last_timestamp = file_time # 가장 최근 파일의 timestamp를 기록한다. delay에 의한 누락을 방지하기 위한 작업.
+                #print(file_list[i])
+        return data_path_list
+
+    else: # 최초 실행이 아닌 경우, 기존에 저장해둔 가장 마지막에 전송한 data의 생성일자를 이용해 전송할 데이터를 골라낸다
+        next_timestamp = last_timestamp # 새로운 last_timestamp 갱신을 위해 새로운 변수 생성
+        for i in range(len(file_list)):
+            file_time = os.path.getmtime(path+'/'+file_list[i])
+            # 이전에 보냈던 latest 파일보다 더욱 최근 파일인 경우, 전송을 시행
+            if file_time > last_timestamp:
+                data_path_list.append(path+'/'+file_list[i])
+                #print(file_list[i])
+                if next_timestamp < file_time:
+                    next_timestamp = file_time # 가장 최근 파일의 timestamp를 기록한다. delay에 의한 누락을 방지하기 위한 작업.
+        last_timestamp = next_timestamp # 작업이 끝나면 last_timestamp를 새로운 값으로 갱신
+        return data_path_list
+
+
+def transport():
+    global host
+    global port
+    global last_timestamp
+    path_list = find_pathlist()
+
+    # 전송의 대상이 되는 파일이 전혀 없었을 경우, 전송을 수행하지 않습니다.
+    if len(path_list) == 0:
+        print("no data to upload")
+        print("waiting...")
+
+    url = F"http://{host}:{port}/upload"
+
+    for i in range(len(path_list)): # 지정된 data path에 존재하는 모든 file에 대해 전송 시행
+        r = requests.post("http://218.232.234.232:2883/upload", data = {"keyValue1":12345}, files = {"attachment":open(path_list[i], "rb")})
+        print(r.text)
+            
+def tick():
+    transport()
+    threading.Timer(measureperiod, tick).start()
+    
+time.sleep(measureperiod)
+tick()

--- a/Raw_Temperature.py
+++ b/Raw_Temperature.py
@@ -1,0 +1,87 @@
+# Raw_Temperature.py
+# date : 2022-05-06
+# 작성자 : ino-on, 주수아
+# 정해진 주기마다 http file server에 raw data를 전송합니다.
+
+from calendar import c
+from encodings import utf_8
+import threading
+import requests
+import json
+import os
+import sys
+import time
+from datetime import datetime
+import numpy as np
+
+measureperiod = 10 # 단위는 sec. 추후 conf.py의 rawperiod로 수정요망
+import conf
+
+connect = conf.config_connect
+
+host = connect["uploadip"]
+port = 2883 # 통일성을 위해 추후 port = connect["uploadport"]로 바꿔야할듯합니다만, uploadport의 기본값이 건기연 서버의 포트와 달라(80) 임시로 상수를 입력해두었습니다.
+
+root=conf.root
+
+last_timestamp = 0
+
+# list find_pathlist()
+# 전송의 대상이 될 파일 list를 출력합니다.
+# 저장되어있는 json file의 생성일자를 모두 살펴본 후, measureperiod동안 생성된 데이터의 path list를 골라냅니다.
+def find_pathlist():
+    global last_timestamp
+    global measureperiod
+    path = "./raw_data/Temperature"
+    file_list = os.listdir(path)
+    present_time = time.time()
+    data_path_list = list()
+
+    if last_timestamp == 0 : # 최초 실행시, 데이터 생성일자에 따라 전송할 데이터를 골라낸다
+        for i in range (len(file_list)):
+            file_time = os.path.getmtime(path+'/'+file_list[i])
+            time_gap = present_time-file_time
+            if time_gap <= measureperiod: # 추후 데이터 수집 범위 10분으로 고정 예정
+                data_path_list.append(path+'/'+file_list[i])
+                if last_timestamp < file_time:
+                    last_timestamp = file_time # 가장 최근 파일의 timestamp를 기록한다. delay에 의한 누락을 방지하기 위한 작업.
+                #print(file_list[i])
+        return data_path_list
+
+    else: # 최초 실행이 아닌 경우, 기존에 저장해둔 가장 마지막에 전송한 data의 생성일자를 이용해 전송할 데이터를 골라낸다
+        next_timestamp = last_timestamp # 새로운 last_timestamp 갱신을 위해 새로운 변수 생성
+        for i in range(len(file_list)):
+            file_time = os.path.getmtime(path+'/'+file_list[i])
+            # 이전에 보냈던 latest 파일보다 더욱 최근 파일인 경우, 전송을 시행
+            if file_time > last_timestamp:
+                data_path_list.append(path+'/'+file_list[i])
+                #print(file_list[i])
+                if next_timestamp < file_time:
+                    next_timestamp = file_time # 가장 최근 파일의 timestamp를 기록한다. delay에 의한 누락을 방지하기 위한 작업.
+        last_timestamp = next_timestamp # 작업이 끝나면 last_timestamp를 새로운 값으로 갱신
+        return data_path_list
+
+
+def transport():
+    global host
+    global port
+    global last_timestamp
+    path_list = find_pathlist()
+
+    # 전송의 대상이 되는 파일이 전혀 없었을 경우, 전송을 수행하지 않습니다.
+    if len(path_list) == 0:
+        print("no data to upload")
+        print("waiting...")
+
+    url = F"http://{host}:{port}/upload"
+
+    for i in range(len(path_list)): # 지정된 data path에 존재하는 모든 file에 대해 전송 시행
+        r = requests.post("http://218.232.234.232:2883/upload", data = {"keyValue1":12345}, files = {"attachment":open(path_list[i], "rb")})
+        print(r.text)
+            
+def tick():
+    transport()
+    threading.Timer(measureperiod, tick).start()
+    
+time.sleep(measureperiod)
+tick()

--- a/conf.py
+++ b/conf.py
@@ -153,6 +153,19 @@ TOPIC_list = {
     "deg":TOPIC_deg
     }
 
+FFT_data_acc = {
+    "use":"Y",
+    "st1min":2.1,
+    "st1max":2.6
+    }
+
+FFT_data_str = {
+    "use":"N",
+    "st1min":2.1,
+    "st1max":2.6
+    }
+    
+
 
 if __name__ == "__main__":
     print(ae)


### PR DESCRIPTION
- Periodical_Acceleration.py에 FFT 연산을 하여 컨텐트인스턴스를 갱신하는 코드를 작성하였습니다.

- FFT 연산을 위해 필요한 값들을 conf.py에 추가하였습니다. 동적 데이터에 대해서만 사용할 것이기 때문에, 가속도와 변형률, 이 두 가지의 센서에 대응하는 딕셔너리를 생성해두었습니다. 각각 **FFT_data_acc, FFT_data_str** 입니다.

- 다만 Periodical_*.py 파일들이 데이터를 전송할 AE를 설정하는 부분이 그냥 string으로 되어있는 AE이름으로 들어가있었습니다. 추후에 수정할 필요가 있을 것 같아, 보기에 용이하도록 주석을 덧붙였습니다.

> +) 220506 20 : 30 추가

- http file server로 특정한 주기마다 raw data를 전송하는 코드를 작성하였습니다. 모비우스 일반규약에 measureperiod와 rawperiod는 따로 있기 때문에, 별도의 py파일을 생성하였습니다.

- 코드 테스트를  위해 10초에 한 번 모든 데이터를 보내도록 만들어둔 상태이나, 실제 시험소에서는 훨씬 낮은 빈도로 데이터를 전송할 예정입니다.